### PR TITLE
chore: move sonarcloud check to separate workflow so its possible to …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          path: app-frontend
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: install node
@@ -23,27 +22,27 @@ jobs:
           node-version: '16'
 
       - name: install dependencies
-        working-directory: app-frontend/src
+        working-directory: src
         env:
           GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: yarn --immutable
 
       - name: run build
-        working-directory: app-frontend/src/altinn-app-frontend
+        working-directory: src/altinn-app-frontend
         run: yarn build
 
       - name: run eslint
-        working-directory: app-frontend/src
+        working-directory: src
         run: yarn lint
 
       - name: run tests
-        working-directory: app-frontend/src
+        working-directory: src
         run: yarn test --coverage
 
-      - name: SonarCloud Scan
+      - name: Upload code coverage reports
+        uses: actions/upload-artifact@v2
         with:
-          projectBaseDir: app-frontend
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          name: code-coverage
+          path: |
+            src/altinn-app-frontend/coverage/lcov.info
+            src/shared/coverage/lcov.info

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -1,0 +1,56 @@
+name: SonarCloud Scan
+on:
+  workflow_run:
+    workflows: ['Build and run unit tests']
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Sonar
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "code-coverage"
+            })[0];
+
+            const download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+
+            const fs = require('node:fs');
+            fs.writeFileSync('${{github.workspace}}/code-coverage.zip', Buffer.from(download.data));
+      - run: unzip code-coverage.zip
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}


### PR DESCRIPTION
…run this on external PR's as well